### PR TITLE
interface: fix `Query` definition

### DIFF
--- a/interface/dbmsInterface.yaml
+++ b/interface/dbmsInterface.yaml
@@ -3,7 +3,7 @@ info:
   title: MIMUW ISBD database system
   description: |-
     This file describes interface between DBMS system and user.
-  version: 1.0.2
+  version: 1.0.1
 tags:
   - name: schema
     description: Endpoints used to access schema structure


### PR DESCRIPTION
Fix typo in `Query` definition properties:
  - `queryString` -> `queryDefinition`

Fixes: #2